### PR TITLE
Expose World IO

### DIFF
--- a/aeson-tiled.cabal
+++ b/aeson-tiled.cabal
@@ -50,6 +50,7 @@ library
     Codec.Tiled.Tileset.WangSet
     Codec.Tiled.Tileset.WangTile
     Codec.Tiled.World
+    Codec.Tiled.World.IO
     Codec.Tiled.World.Map
     Codec.Tiled.World.Pattern
     Data.Tiled.GID

--- a/aeson-tiled.cabal
+++ b/aeson-tiled.cabal
@@ -16,10 +16,11 @@ category: Game Engine
 build-type: Simple
 
 extra-source-files:
-  README.md,
-  ChangeLog.md,
   maps/microgue/*.tmj,
   maps/microgue/*.tsj
+extra-doc-files:
+  README.md,
+  ChangeLog.md
 
 library
   hs-source-dirs: src

--- a/aeson-tiled.cabal
+++ b/aeson-tiled.cabal
@@ -110,3 +110,7 @@ test-suite aeson-tiled-test
     PatternSynonyms,
     RecordWildCards,
     StrictData,
+
+source-repository head
+    type:     git
+    location: https://github.com/haskell-game/aeson-tiled


### PR DESCRIPTION
One liner to expose a very useful `IO` module for `World`.

Additionally fixed things that `cabal check` complained about.