### PR TITLE
Make `propertytype` optional

### DIFF
--- a/maps/property-name.tmj
+++ b/maps/property-name.tmj
@@ -1,0 +1,34 @@
+{ "compressionlevel":-1,
+ "height":4,
+ "infinite":false,
+ "layers":[
+        {
+         "data":[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+         "height":4,
+         "id":1,
+         "name":"Tile Layer 1",
+         "opacity":1,
+         "type":"tilelayer",
+         "visible":true,
+         "width":4,
+         "x":0,
+         "y":0
+        }],
+ "nextlayerid":2,
+ "nextobjectid":1,
+ "orientation":"orthogonal",
+ "properties":[
+        {
+         "name":"test",
+         "type":"string",
+         "value":"foo"
+        }],
+ "renderorder":"right-down",
+ "tiledversion":"1.8.2",
+ "tileheight":10,
+ "tilesets":[],
+ "tilewidth":10,
+ "type":"map",
+ "version":"1.8",
+ "width":4
+}

--- a/src/Codec/Tiled/Property.hs
+++ b/src/Codec/Tiled/Property.hs
@@ -9,7 +9,7 @@ import Codec.Tiled.Aeson (FromJSON(..), ToJSON(..), genericParseJSON, genericToJ
 data Property = Property
   { name         :: Text       -- ^ Name of the property
   , type_        :: Maybe Text -- ^ Type of the property (@string@ (default), @int@, @float@, @bool@, @color@, @file@, @object@ or @class@)
-  , propertyType :: Text       -- ^ Name of the custom property type, when applicable
+  , propertyType :: Maybe Text -- ^ Name of the custom property type, when applicable
   , value        :: Value      -- ^ Value of the property
   }
   deriving (Eq, Show, Generic)

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -24,6 +24,8 @@ mapCodecTests = testGroup "Map"
       [ testCase "Embedded tileset" mapTestRoundtripEmbedded
       , testCase "External tileset" mapTestRoundtripExternal
       ]
+  , testGroup "Custom properties"
+      [ testCase "Property name" mapTestPropertyName ]
   ]
 
 mapTestRoundtripEmbedded :: IO ()
@@ -43,6 +45,13 @@ mapTestRoundtripExternal = do
     Map.writeFile out embeddedZstd
     embeddedZstdOut <- Map.readFile out
     embeddedZstd @?= embeddedZstdOut
+
+mapTestPropertyName :: IO ()
+mapTestPropertyName = do
+  testMap <- Map.readFile "maps/property-name.tmj"
+  print testMap
+    -- This will fail with “key "propertytype" not found” or
+    -- similar if aeson is not able to parse it correctly.
 
 tilesetCodecTests :: TestTree
 tilesetCodecTests = testGroup "Tileset"


### PR DESCRIPTION
Per tiled docs, `propertytype` is optional (“when applicable”).